### PR TITLE
Use peerDependencies for React

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
   "license": "MIT",
   "dependencies": {
     "jquery": "^2.1.1",
-    "react": "^0.11.1",
     "tinycolor2": "^1.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=0.11.0"
   },
   "devDependencies": {
     "browserify": "^4.2.3",


### PR DESCRIPTION
Directly depending on React means on a version change, users of this module will have two incompatible versions of React loaded into their browser :) Not fun.
